### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SvelteKit Library Pacakge Template
 
-IMO some things in the default template are mssing for using sveltekits awesome package feature to publish a library with docs and demo (and tests at some point maybe?)
+IMO some things in the default template are missing for using sveltekits awesome package feature to publish a library with docs and demo (and tests at some point maybe?)
 
 I've this based on `create-svelte` (i.e. `npm init svelte@next`) with TS, ES Lint and Prettier plus the `npm run package` script, mdsvex for stupidly simple markdown docs and a `Build and Deploy Lib and Docs` GitHub workflow
 


### PR DESCRIPTION
## What?

This pull requests fixes a typo in the README.md file. In line 3 of the README.md file, the word _missing_ is misspelled as `mssing`.

## Why?

`missing` is spelled with an `i` character between the `m` character and the `s` character.

## How?

I edited the file using the GitHub web editor.

## Testing?

Looking at the preview, it seems to be fixed in this proposed version.

## Screenshots (optional)

<img width="805" alt="Screenshot 2022-01-13 at 14 52 23" src="https://user-images.githubusercontent.com/23481219/149342757-d2969bee-ff3a-4026-bbd7-93dac07ed29a.png">

## Anything Else?

Much wow.
